### PR TITLE
correct handling of numerics

### DIFF
--- a/src/main/java/com/aerospike/jdbc/AerospikeConnection.java
+++ b/src/main/java/com/aerospike/jdbc/AerospikeConnection.java
@@ -439,7 +439,7 @@ public class AerospikeConnection extends AbstractConnection implements Connectio
 					statement.setFilters(Filter.equal(whereArray[0].trim(),whereArray[1].replace("'", "").trim()));
 				}else{
 					createIndex(pSelect,whereArray,"NUMERIC");
-					statement.setFilters(Filter.equal(whereArray[0].trim(),whereArray[1].trim()));
+					statement.setFilters(Filter.equal(whereArray[0].trim(),Long.parseLong(whereArray[1].trim())));
 				}
 	
 			}


### PR DESCRIPTION
without this fix 'index not found' is thrown for queries involving numerics, like: 
select * from GroupChat where archived=1